### PR TITLE
cookie support in Ethereum::HttpClient

### DIFF
--- a/lib/ethereum/http_client.rb
+++ b/lib/ethereum/http_client.rb
@@ -28,7 +28,12 @@ module Ethereum
     end
 
     def send_batch(batch)
-      raise NotImplementedError
+      result = send_single(batch.to_json)
+      result = JSON.parse(result)
+
+      # Make sure the order is the same as it was when batching calls
+      # See 6 Batch here http://www.jsonrpc.org/specification
+      return result.sort_by! { |c| c['id'] }  
     end
   end
 


### PR DESCRIPTION
# Motivation

I'm operating several Ethereum server instances behind load balancer such as ELB.
some JSON-RPC methods such as filter related functions should process by same backend instance.

e.g. eth_newFilter and eth_getFilterChanges requests should be execute in same instance.

To resolve this problem, using cookie based session affinity feature to load balancer, then make this client compatible for its feature.

# Resolution

Handles set-cookie header if call with `cookie: true` header.
This implementation is very limited,  lack of some basic implementation such as expiration and persistence.

# Reference

- [Target Groups for Your Application Load Balancers - Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#sticky-sessions) > Sticky Sessions
- [Backend Services | Compute Engine Documentation | Google Cloud](https://cloud.google.com/compute/docs/load-balancing/http/backend-service?hl=en#generated_cookie_affinity) > Setting generated cookie affinity